### PR TITLE
fix crashing when no pending pod found

### DIFF
--- a/pkg/plugin/vgpu/plugin.go
+++ b/pkg/plugin/vgpu/plugin.go
@@ -308,6 +308,11 @@ func (m *NvidiaDevicePlugin) Allocate(ctx context.Context, reqs *pluginapi.Alloc
 		lock.ReleaseNodeLock(nodename, util.VGPUDeviceName)
 		return &pluginapi.AllocateResponse{}, err
 	}
+	if current == nil {
+		klog.Errorf("no pending pod found on node %s", nodename)
+		lock.ReleaseNodeLock(nodename, util.VGPUDeviceName)
+		return &pluginapi.AllocateResponse{}, errors.New("no pending pod found on node")
+	}
 
 	for idx := range reqs.ContainerRequests {
 		currentCtr, devreq, err := util.GetNextDeviceRequest(util.NvidiaGPUDevice, *current)


### PR DESCRIPTION
fix #2 

https://github.com/Project-HAMi/volcano-vgpu-device-plugin/blob/ecb8a511dd594f5385f1fdee75b938ee911527f0/pkg/plugin/vgpu/plugin.go#L306-L314

When `current` is nil, lead to nil pointer crashing L313

