### PR TITLE
Fix get pending pod failed

### DIFF
--- a/pkg/plugin/vgpu/util/types.go
+++ b/pkg/plugin/vgpu/util/types.go
@@ -24,6 +24,9 @@ const (
 	BindTimeAnnotations              = "volcano.sh/bind-time"
 	DeviceBindPhase                  = "volcano.sh/bind-phase"
 
+	// PodAnnotationMaxLength pod annotation max data length 1MB
+	PodAnnotationMaxLength = 1024 * 1024
+
 	GPUInUse = "nvidia.com/use-gputype"
 	GPUNoUse = "nvidia.com/nouse-gputype"
 


### PR DESCRIPTION
**Problem**: When there are many Pods were scheduled to this node at the same time, it's possible that the function GetPendingPod() returns Pod not the one which kubelet wants to allocate vGPUs for. And finally, the allocated GPU resources is not correct.

**Fix**: Get the oldest Pod in terms of "vgpu-time",  so that the returned Pod is always the one which kubelet wants to allocate vGPUs for.