### PR TITLE
Register device memory using the GPU memory factor

### DIFF
--- a/pkg/plugin/vgpu/register.go
+++ b/pkg/plugin/vgpu/register.go
@@ -62,7 +62,8 @@ func (r *DeviceRegister) apiDevices() *[]*util.DeviceInfo {
 		} else {
 			klog.V(3).Infoln("nvml registered device id=", dev.ID, "memory=", *ndev.Memory, "type=", *ndev.Model)
 		}
-		registeredmem := int32(*ndev.Memory)
+		registeredmem := int32(*ndev.Memory) / int32(config.GPUMemoryFactor)
+		klog.V(3).Infoln("GPUMemoryFactor=", config.GPUMemoryFactor, "registeredmem=", registeredmem)
 		res = append(res, &util.DeviceInfo{
 			Id:     dev.ID,
 			Count:  int32(config.DeviceSplitCount),


### PR DESCRIPTION
When using the GPUMemoryFactor argument without specifying vgpu-memory in the request, pod allocation relies on the total gpumem multiplied by the factor. 

This PR fixes this bug, aligning device memory registration with GPUMemoryFactor, ensuring pod allocation matches the total gpumem.