### PR TITLE
filter pods by node name and improve oldest pod selection logic

### DIFF
--- a/pkg/plugin/vgpu/util/util.go
+++ b/pkg/plugin/vgpu/util/util.go
@@ -59,7 +59,12 @@ func GetNode(nodename string) (*v1.Node, error) {
 }
 
 func GetPendingPod(node string) (*v1.Pod, error) {
-	podList, err := lock.GetClient().CoreV1().Pods("").List(context.Background(), metav1.ListOptions{})
+	// filter pods for this node.
+	selector := fmt.Sprintf("spec.nodeName=%s", node)
+	podListOptions := metav1.ListOptions{
+		FieldSelector: selector,
+	}
+	podList, err := lock.GetClient().CoreV1().Pods("").List(context.Background(), podListOptions)
 	if err != nil {
 		return nil, err
 	}
@@ -76,21 +81,38 @@ func getOldestPod(pods []v1.Pod) *v1.Pod {
 	if len(pods) == 0 {
 		return nil
 	}
-	oldest := pods[0]
-	for _, pod := range pods {
-		klog.V(4).Infof("pod %s, predicate time: %s", pod.Name, pod.Annotations[AssignedTimeAnnotations])
-		if getPredicateTimeFromPodAnnotation(&oldest) > getPredicateTimeFromPodAnnotation(&pod) {
-			oldest = pod
+	var oldest *v1.Pod = nil
+	for i, pod := range pods {
+		if pod.Status.Phase != v1.PodPending {
+			continue
 		}
+		if _, ok := pod.Annotations[BindTimeAnnotations]; !ok {
+			continue
+		}
+		if phase, ok := pod.Annotations[DeviceBindPhase]; !ok {
+			continue
+		} else {
+			if strings.Compare(phase, DeviceBindAllocating) != 0 {
+				continue
+			}
+		}
+		klog.V(4).Infof("pod %s, predicate time: %s", pod.Name, pod.Annotations[AssignedTimeAnnotations])
+		if oldest == nil || getPredicateTimeFromPodAnnotation(oldest) > getPredicateTimeFromPodAnnotation(&pod) {
+			oldest = &pods[i]
+		}
+	}
+	if oldest == nil {
+		klog.Warningf("no pod has predicate time")
+		return nil
 	}
 	klog.V(4).Infof("oldest pod %#v, predicate time: %#v", oldest.Name,
 		oldest.Annotations[AssignedTimeAnnotations])
 	annotation := map[string]string{AssignedTimeAnnotations: strconv.FormatUint(math.MaxUint64, 10)}
-	if err := PatchPodAnnotations(&oldest, annotation); err != nil {
+	if err := PatchPodAnnotations(oldest, annotation); err != nil {
 		klog.Errorf("update pod %s failed, err: %v", oldest.Name, err)
 		return nil
 	}
-	return &oldest
+	return oldest
 }
 
 func getPredicateTimeFromPodAnnotation(pod *v1.Pod) uint64 {


### PR DESCRIPTION
The device plugin allocates a device by selecting the oldest pod, but it did not filter pods by node. This caused a bug if different nodes' pods have the same time assigned by Volcano (e.g., a Gang scheduler). It may get a pod on another node and so assign another node's GPU.

This PR fixes that bug by filtering pods by node name and also improves the oldest pod selection logic by filtering pods that are pending and have the right Volcano annotations.

Hami implement reference: https://github.com/Project-HAMi/HAMi/pull/340