### PR TITLE
Make GPU Health comparison case-insensitive

### DIFF
--- a/pkg/plugin/vgpu/register.go
+++ b/pkg/plugin/vgpu/register.go
@@ -18,6 +18,7 @@ package vgpu
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/NVIDIA/gpu-monitoring-tools/bindings/go/nvml"
@@ -69,7 +70,7 @@ func (r *DeviceRegister) apiDevices() *[]*util.DeviceInfo {
 			Count:  int32(config.DeviceSplitCount),
 			Devmem: registeredmem,
 			Type:   fmt.Sprintf("%v-%v", "NVIDIA", *ndev.Model),
-			Health: dev.Health == "healthy",
+			Health: strings.EqualFold(dev.Health, "healthy"),
 		})
 	}
 	return &res


### PR DESCRIPTION
Updated the volcano-device-plugin to compare the Health annotation using `strings.EqualFold(dev.Health, "healthy")` instead of a case-sensitive check. This ensures that GPU health status is correctly recognized regardless of the casing used in the annotation.