### PR TITLE
[fix] configmap中的配置同步到全部变量config中

### DIFF
--- a/pkg/plugin/vgpu/util/util.go
+++ b/pkg/plugin/vgpu/util/util.go
@@ -217,7 +217,7 @@ func DecodeContainerDevices(str string) (c ContainerDevices, count int) {
 			devcores, _ := strconv.ParseInt(tmpstr[3], 10, 32)
 			tmpdev.Usedcores = int32(devcores)
 			contdev = append(contdev, tmpdev)
-            klog.V(4).Infoln("val=", val)
+			klog.V(4).Infoln("val=", val)
 		}
 	}
 	//klog.V(4).Infoln("contdev=", contdev)
@@ -592,6 +592,12 @@ func LoadNvidiaConfig() *config.NvidiaConfig {
 		klog.InfoS("readFrom device cm error", err.Error())
 	}
 	klog.Infoln("Loaded config=", nvidiaConfig)
+	// Sync the loaded config back to global variables so that
+	// register.go and plugin.go can use the correct values
+	config.DeviceSplitCount = nvidiaConfig.DeviceSplitCount
+	config.DeviceCoresScaling = nvidiaConfig.DeviceCoreScaling
+	config.GPUMemoryFactor = nvidiaConfig.GPUMemoryFactor
+
 	return &nvidiaConfig
 }
 


### PR DESCRIPTION
bug fix。
场景：
使用configmap： volcano-vgpu-node-config按节点维度配置vGPU规则，实际节点上的vGPU卡数量同配置中的不一致。
问题原因：
全局变量config未同步来自configmap中的配置，导致更新节点vGPU卡信息时出错。
修改方案：
使用configmap中的配置同步全部变量config