### PR TITLE
vgpu-monitor panics with invalid UTF-8 when collecting per-container metrics during container initialization

### DIFF
--- a/cmd/vgpu-monitor/metrics.go
+++ b/cmd/vgpu-monitor/metrics.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"volcano.sh/k8s-device-plugin/pkg/monitor/nvidia"
 	"volcano.sh/k8s-device-plugin/pkg/plugin/vgpu/config"
@@ -225,6 +226,10 @@ func (cc ClusterManagerCollector) Collect(ch chan<- prometheus.Metric) {
 				}
 				for i := 0; i < c.Info.DeviceNum(); i++ {
 					uuid := c.Info.DeviceUUID(i)[0:40]
+					if !utf8.ValidString(uuid) {
+						klog.Warningf("skipping device %d for pod %s/%s: UUID contains invalid UTF-8 (shared memory not yet initialized)", i, pod.Namespace, pod.Name)
+						continue
+					}
 					memoryTotal := c.Info.DeviceMemoryTotal(i)
 					memoryLimit := c.Info.DeviceMemoryLimit(i)
 					memoryContextSize := c.Info.DeviceMemoryContextSize(i)


### PR DESCRIPTION
## Problem

The vgpu-monitor panics on every scrape cycle when a HAMi-managed container is initializing, causing no per-container vGPU metrics to be emitted for any workload.

`DeviceUUID()` reads the GPU UUID from shared memory written by `libvgpu.so` inside the container. Before CUDA has fully initialized, this memory is uninitialized/zeroed. The raw bytes are sliced to 40 characters and passed directly as a Prometheus label value to `MustNewConstMetric`, which panics:

```
panic: label value "\x80\x00\x00\x00..." is not valid UTF-8

goroutine 426 [running]:
github.com/prometheus/client_golang/prometheus.MustNewConstMetric(...)
main.ClusterManagerCollector.Collect(...)
    /go/src/volcano.sh/devices/cmd/vgpu-monitor/metrics.go:238
```

## Fix

Validate the UUID is valid UTF-8 before calling `MustNewConstMetric`. If not, log a warning and skip the device for this scrape cycle. On the next cycle, once `libvgpu.so` has written the UUID to shared memory, the metric will be collected normally.

## Testing

- Verified panic occurs on `prod-ltx1-k8s-2` node `ltx1-app157276` (pool `gpu-nvidia-h100-ssd-hami-kjp`) with a PyTorch job requesting only `volcano.sh/vgpu-*` resources
- Confirmed `libvgpu.so` and `ld.so.preload` are correctly injected by the device plugin at container start
- Fix prevents the panic; device will be retried on next scrape once shared memory is initialized