### PR TITLE
fix: the configuration in the `ConfigMap` may be overwritten by command-line parameters

### DIFF
--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -576,10 +576,11 @@ func LoadNvidiaConfig(c *cli.Context) *config.NvidiaConfig {
 	nvidiaConfig := config.NvidiaConfig{}
 	if configs != nil {
 		nvidiaConfig = configs.NvidiaConfig
+	} else {
+		nvidiaConfig.DeviceSplitCount = config.DeviceSplitCount
+		nvidiaConfig.DeviceCoreScaling = config.DeviceCoresScaling
+		nvidiaConfig.GPUMemoryFactor = config.GPUMemoryFactor
 	}
-	nvidiaConfig.DeviceSplitCount = config.DeviceSplitCount
-	nvidiaConfig.DeviceCoreScaling = config.DeviceCoresScaling
-	nvidiaConfig.GPUMemoryFactor = config.GPUMemoryFactor
 	if err := readFromConfigFile(&nvidiaConfig); err != nil {
 		klog.InfoS("readFrom device cm error", err.Error())
 	}


### PR DESCRIPTION
#98 tried to solve this problem but didn't completely fix it