### PR TITLE
fix: apply filterdevices configuration during device registration

### DIFF
--- a/pkg/rm/device_map.go
+++ b/pkg/rm/device_map.go
@@ -26,6 +26,7 @@ import (
 	pluginapi "k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
 
 	spec "volcano.sh/k8s-device-plugin/api/config/v1"
+	config "volcano.sh/k8s-device-plugin/pkg/config"
 )
 
 type deviceMapBuilder struct {
@@ -110,6 +111,16 @@ func (b *deviceMapBuilder) buildGPUDeviceMap() (DeviceMap, error) {
 	devices := make(DeviceMap)
 
 	err := b.VisitDevices(func(i int, gpu device.Device) error {
+		// Get UUID for filtering
+		uuid, ret := gpu.GetUUID()
+		if ret != nvml.SUCCESS {
+			return fmt.Errorf("error getting UUID for GPU at index %d: %v", i, ret)
+		}
+		// Check if device should be filtered based on filterdevice configuration
+		if config.FilterDeviceToRegister(uuid, i) {
+			klog.V(3).Infoln("Filtering device in buildGPUDeviceMap based on filterdevice config: index=%d, uuid=%s", i, uuid)
+			return nil
+		}
 		name, ret := gpu.GetName()
 		if ret != nvml.SUCCESS {
 			return fmt.Errorf("error getting product name for GPU: %v", ret)


### PR DESCRIPTION
The filterdevice configuration defined in the configmap: volcano-vgpu-node-config could be read correctly but not applied during device registration.

The feature was introduced by commit e7d4347b which add the support to filter GPU.

The issue was introduced during the v0.19.0 sync (commit 621c67bf) when the old vgpu framework was removed.


This PR is tested by myself in my local environment.