### PR TITLE
fix(config): respect ConfigMap values when CLI flag is not explicitly set

### DIFF
--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -577,9 +577,23 @@ func LoadNvidiaConfig(c *cli.Context) *config.NvidiaConfig {
 	if configs != nil {
 		nvidiaConfig = configs.NvidiaConfig
 	}
-	nvidiaConfig.DeviceSplitCount = config.DeviceSplitCount
-	nvidiaConfig.DeviceCoreScaling = config.DeviceCoresScaling
-	nvidiaConfig.GPUMemoryFactor = config.GPUMemoryFactor
+	// Only let CLI flags override the values loaded from the ConfigMap when the
+	// user has explicitly set them. Without this guard the per-flag default
+	// (e.g. --gpu-memory-factor=1) silently overwrites whatever the operator
+	// configured in the ConfigMap, which makes the ConfigMap field useless and
+	// is confusing to debug — see e.g.
+	// https://github.com/Project-HAMi/volcano-vgpu-device-plugin/issues for
+	// the symptom (`Allocatable: volcano.sh/vgpu-memory: 0` on large GPUs
+	// because the ConfigMap-supplied factor is silently ignored).
+	if c.IsSet("device-split-count") {
+		nvidiaConfig.DeviceSplitCount = config.DeviceSplitCount
+	}
+	if c.IsSet("device-cores-scaling") {
+		nvidiaConfig.DeviceCoreScaling = config.DeviceCoresScaling
+	}
+	if c.IsSet("gpu-memory-factor") {
+		nvidiaConfig.GPUMemoryFactor = config.GPUMemoryFactor
+	}
 	if err := readFromConfigFile(&nvidiaConfig); err != nil {
 		klog.InfoS("readFrom device cm error", err.Error())
 	}


### PR DESCRIPTION
## Summary

`LoadNvidiaConfig()` (`pkg/util/util.go`) loads the device-plugin
ConfigMap (`volcano-vgpu-device-config`) into `nvidiaConfig`, and then
**unconditionally** overwrites `DeviceSplitCount`, `DeviceCoreScaling`,
and `GPUMemoryFactor` with the matching CLI flag values:

```go
nvidiaConfig.DeviceSplitCount  = config.DeviceSplitCount
nvidiaConfig.DeviceCoreScaling = config.DeviceCoresScaling
nvidiaConfig.GPUMemoryFactor   = config.GPUMemoryFactor
```

Because each flag carries a per-flag default (`--gpu-memory-factor=1`,
`--device-split-count=2`, etc.), this silently discards whatever the
operator put in the ConfigMap, **even when the flag is never passed on
the command line.**

## Symptom that surfaced this

On a node with 2 × 46 GiB GPUs, an operator sets
`gpuMemoryFactor: 1024` in the ConfigMap so the device-plugin advertises
~88 vgpu-memory devices instead of ~92 K (so the kubelet ↔ plugin
ListAndWatch gRPC stays under the default 4 MiB receive limit). The
CLI default (1) silently overrode the ConfigMap, the plugin advertised
~92 K devices, kubelet dropped the advertise, and `kubectl describe
node` reported:

```text
Allocatable:
  volcano.sh/vgpu-cores:  "200"
  volcano.sh/vgpu-memory: "0"     # <- dropped
  volcano.sh/vgpu-number: "20"
```

The Volcano scheduler's `capacity` plugin then computes
`realCapability = min(cluster_total, queue.capability) = 0` and rejects
every Pod with `queue resource quota insufficient: insufficient volcano.sh/vgpu-memory` — even when the queue capability is set
correctly.

The only way to make the ConfigMap-supplied value take effect today is
to also pass the same value via the DaemonSet `args:`, which makes the
ConfigMap field useless.

## Fix

Gate the CLI-flag override on `cli.Context.IsSet()` so the flag wins
only when the user actually passed it on the command line.

```go
if c.IsSet("device-split-count") {
    nvidiaConfig.DeviceSplitCount = config.DeviceSplitCount
}
if c.IsSet("device-cores-scaling") {
    nvidiaConfig.DeviceCoreScaling = config.DeviceCoresScaling
}
if c.IsSet("gpu-memory-factor") {
    nvidiaConfig.GPUMemoryFactor = config.GPUMemoryFactor
}
```

## Compatibility

- **No flags + no ConfigMap** → values remain zero (unchanged).
- **No flags + ConfigMap set** → ConfigMap wins (was previously: flag default silently won).
- **Flag explicitly passed** → flag wins (unchanged).
- **Flag explicitly passed + ConfigMap set** → flag wins (unchanged, matches typical CLI-over-config precedence).

The only behavior change is the second case — and that is the case the
ConfigMap fields exist for, so it's the bug-fix direction.

## Test plan

- [x] `go build ./pkg/util/...` ✓
- [x] Reproduced the original 0-allocatable symptom on RTX 6000 Ada × 2 with the upstream binary.
- [x] Built the plugin from this branch, kept the `--gpu-memory-factor` flag out of the DaemonSet `args`, set `gpuMemoryFactor: 1024` only in the ConfigMap → node Allocatable correctly reports `volcano.sh/vgpu-memory: 88` and Pods with `volcano.sh/vgpu-memory: 23` (chunks) schedule and run.

## Related

The 4 MiB ListAndWatch limit and the `gpuMemoryFactor` mitigation are
documented in [#118](https://github.com/Project-HAMi/volcano-vgpu-device-plugin/pull/118)'s README troubleshooting section. That PR is purely docs; this is the underlying behavior fix.