### PR TITLE
fix: replace deprecated apt-key add with gpg --dearmor + signed-by

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,10 @@ This is because the new `--gpus` options hasn't reached kubernetes yet. Example:
 ```bash
 # Add the package repositories
 $ distribution=$(. /etc/os-release;echo $ID$VERSION_ID)
-$ curl -s -L https://nvidia.github.io/nvidia-docker/gpgkey | sudo apt-key add -
-$ curl -s -L https://nvidia.github.io/nvidia-docker/$distribution/nvidia-docker.list | sudo tee /etc/apt/sources.list.d/nvidia-docker.list
+$ curl -fsSL https://nvidia.github.io/nvidia-docker/gpgkey | sudo gpg --dearmor -o /usr/share/keyrings/nvidia-docker-keyring.gpg
+$ curl -s -L https://nvidia.github.io/nvidia-docker/$distribution/nvidia-docker.list | \
+    sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-docker-keyring.gpg] https://#g' | \
+    sudo tee /etc/apt/sources.list.d/nvidia-docker.list
 
 $ sudo apt-get update && sudo apt-get install -y nvidia-docker2
 $ sudo systemctl restart docker


### PR DESCRIPTION
## Summary
- Replace deprecated `apt-key add` with `gpg --dearmor` to store GPG keyring
- Add `signed-by` option in apt sources.list for per-repository key isolation
- Reference: https://github.com/Project-HAMi/website/pull/236

## Test plan
- [x] Verify the commands work on Ubuntu 22.04+ / Debian 12+
- [x] Confirm `apt-get update` succeeds without key errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)