### PR TITLE
feat: Update libvgpu and CUDA builder image

### DIFF
--- a/docker/Dockerfile.ubuntu20.04
+++ b/docker/Dockerfile.ubuntu20.04
@@ -28,7 +28,7 @@ RUN go build -ldflags="-s -w" -o volcano-vgpu-device-plugin ./cmd/vgpu
 RUN go build -ldflags="-s -w" -o volcano-vgpu-monitor ./cmd/vgpu-monitor
 RUN go install github.com/NVIDIA/mig-parted/cmd/nvidia-mig-parted@latest
 
-FROM nvidia/cuda:12.2.0-devel-ubuntu20.04 AS nvidia_builder
+FROM nvidia/cuda:12.9.1-cudnn-devel-ubuntu20.04 AS nvidia_builder
 ARG TARGETARCH
 RUN apt-get update
 RUN apt-get -y install wget openssl libssl-dev


### PR DESCRIPTION
- Upgrade libvgpu(hami-core) to the latest commit: [8c32de630b24f5f7d6355fbeb0034845d3bdafb7](https://github.com/Project-HAMi/HAMi-core/blob/8c32de630b24f5f7d6355fbeb0034845d3bdafb7).
- Make cuda env in build image consistent with [hami-core](https://github.com/Project-HAMi/HAMi-core/blob/e3c3477ee36ab3ef84de6afd38ada02cf7ce2d6f/dockerfiles/Dockerfile#L1).