### PR TITLE
Add CUDA_DISABLE_CONTROL_DP environment variable support

### DIFF
--- a/pkg/plugin/server.go
+++ b/pkg/plugin/server.go
@@ -453,6 +453,11 @@ func (plugin *nvidiaDevicePlugin) Allocate(ctx context.Context, reqs *pluginapi.
 						break
 					}
 				}
+
+				if !found && os.Getenv("CUDA_DISABLE_CONTROL_DP") != "" {
+					found = true
+				}
+
 				if !found {
 					response.Mounts = append(response.Mounts, &pluginapi.Mount{ContainerPath: "/etc/ld.so.preload",
 						HostPath: hostHookPath + "/ld.so.preload",


### PR DESCRIPTION
Adds a new environment variable to allow disabling CUDA control functionality at the device plugin level.

When the CUDA hijack shared library injected by the HAMI device-plugin causes failures in inference services across multiple Pods, you can quickly disable the CUDA hijack shared library via this configuration, eliminating the need to modify the configuration of each business Pod one by one.