### PR TITLE
Match vGPU allocation by pod identity and device IDs

### DIFF
--- a/pkg/plugin/server.go
+++ b/pkg/plugin/server.go
@@ -45,6 +45,7 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 	"gopkg.in/yaml.v2"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
 	pluginapi "k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
 )
@@ -349,18 +350,22 @@ func (plugin *nvidiaDevicePlugin) Allocate(ctx context.Context, reqs *pluginapi.
 		return &responses, nil
 	}
 	nodeName := os.Getenv("NODE_NAME")
-	gpuAmount := len(reqs.ContainerRequests[0].DevicesIds)
-	current, err := util.GetPendingPod(nodeName, gpuAmount)
-	if err != nil {
-		nodelock.ReleaseNodeLock(nodeName, util.VGPUDeviceName)
-		return &pluginapi.AllocateResponse{}, err
+	var current *corev1.Pod
+	if strings.Contains(reqs.ContainerRequests[0].DevicesIds[0], "MIG") {
+		gpuAmount := len(reqs.ContainerRequests[0].DevicesIds)
+		var err error
+		current, err = util.GetPendingPod(nodeName, gpuAmount)
+		if err != nil {
+			nodelock.ReleaseNodeLock(nodeName, util.VGPUDeviceName)
+			return &pluginapi.AllocateResponse{}, err
+		}
+		if current == nil {
+			klog.Errorf("no pending pod found on node %s", nodeName)
+			nodelock.ReleaseNodeLock(nodeName, util.VGPUDeviceName)
+			return &pluginapi.AllocateResponse{}, errors.New("no pending pod found on node")
+		}
+		klog.V(3).InfoS("Current pending pod.", "UID", current.UID, "pod name", current.Name)
 	}
-	if current == nil {
-		klog.Errorf("no pending pod found on node %s", nodeName)
-		nodelock.ReleaseNodeLock(nodeName, util.VGPUDeviceName)
-		return &pluginapi.AllocateResponse{}, errors.New("no pending pod found on node")
-	}
-	klog.V(3).InfoS("Current pending pod.", "UID", current.UID, "pod name", current.Name)
 
 	for idx, req := range reqs.ContainerRequests {
 		if strings.Contains(req.DevicesIds[0], "MIG") {
@@ -386,14 +391,20 @@ func (plugin *nvidiaDevicePlugin) Allocate(ctx context.Context, reqs *pluginapi.
 			responses.ContainerResponses = append(responses.ContainerResponses, response)
 		} else {
 
-			currentCtr, devreq, err := util.GetNextDeviceRequest(util.NvidiaGPUDevice, *current)
-			klog.V(4).InfoS("Selected Pod deviceAllocateFromAnnotation=", "request", devreq)
-			//klog.V(4).InfoS("reqs device ids=", "deviceIDs", reqs.ContainerRequests[idx].DevicesIDs)
+			var (
+				currentCtr corev1.Container
+				devreq     util.ContainerDevices
+				err        error
+			)
+			current, currentCtr, devreq, err = util.GetMatchingPendingDeviceRequest(util.NvidiaGPUDevice, nodeName, req.DevicesIds)
 			if err != nil {
-				klog.Errorln("get device from annotation failed", err.Error())
-				util.PodAllocationFailed(nodeName, current)
+				klog.Errorln("get matching device request failed", err.Error())
+				nodelock.ReleaseNodeLock(nodeName, util.VGPUDeviceName)
 				return &pluginapi.AllocateResponse{}, err
 			}
+			klog.V(3).InfoS("Current pending pod.", "UID", current.UID, "pod name", current.Name)
+			klog.V(4).InfoS("Selected Pod deviceAllocateFromAnnotation=", "request", devreq)
+			//klog.V(4).InfoS("reqs device ids=", "deviceIDs", reqs.ContainerRequests[idx].DevicesIDs)
 			if len(devreq) != len(reqs.ContainerRequests[idx].DevicesIds) {
 				klog.Errorln("device number not matched", devreq, reqs.ContainerRequests[idx].DevicesIds)
 				util.PodAllocationFailed(nodeName, current)

--- a/pkg/util/types.go
+++ b/pkg/util/types.go
@@ -25,6 +25,9 @@ const (
 	AssignedIDsAnnotations           = "volcano.sh/vgpu-ids-new"
 	AssignedIDsToAllocateAnnotations = "volcano.sh/devices-to-allocate"
 	AssignedNodeAnnotations          = "volcano.sh/vgpu-node"
+	AssignedPodNameAnnotations       = "volcano.sh/vgpu-pod-name"
+	AssignedPodNamespaceAnnotations  = "volcano.sh/vgpu-pod-namespace"
+	AssignedPodUIDAnnotations        = "volcano.sh/vgpu-pod-uid"
 	BindTimeAnnotations              = "volcano.sh/bind-time"
 	DeviceBindPhase                  = "volcano.sh/bind-phase"
 

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -69,6 +69,14 @@ func GetPendingPod(node string, gpuAmount int) (*v1.Pod, error) {
 	return oldestPod, nil
 }
 
+func GetMatchingPendingDeviceRequest(dtype, nodeName string, requestedDeviceIDs []string) (*v1.Pod, v1.Container, ContainerDevices, error) {
+	podList, err := client.GetClient().CoreV1().Pods("").List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		return nil, v1.Container{}, nil, err
+	}
+	return GetMatchingDeviceRequest(dtype, nodeName, requestedDeviceIDs, podList.Items)
+}
+
 //func printPodList(pods []v1.Pod, kubeletRequestAmount int) {
 //	for _, pod := range pods {
 //		_, length := DecodePodDevices(pod.Annotations[AssignedIDsToAllocateAnnotations])
@@ -247,6 +255,86 @@ func GetNextDeviceRequest(dtype string, p v1.Pod) (v1.Container, ContainerDevice
 		}
 	}
 	return v1.Container{}, res, errors.New("device request not found")
+}
+
+func GetMatchingDeviceRequest(dtype, nodeName string, requestedDeviceIDs []string, pods []v1.Pod) (*v1.Pod, v1.Container, ContainerDevices, error) {
+	var matchedPod *v1.Pod
+	var matchedContainer v1.Container
+	var matchedDevices ContainerDevices
+	matchCount := 0
+
+	for i := range pods {
+		pod := &pods[i]
+		if !podMatchesNode(pod, nodeName) || !podIdentityAnnotationsMatch(pod) {
+			continue
+		}
+		pdevices, _ := DecodePodDevices(pod.Annotations[AssignedIDsToAllocateAnnotations])
+		for idx, val := range pdevices {
+			devices := devicesOfType(dtype, val)
+			if len(devices) == 0 || !deviceIDsMatch(devices, requestedDeviceIDs) {
+				continue
+			}
+			if idx >= len(pod.Spec.Containers) {
+				klog.Warningf("skipping malformed device annotation on pod %s/%s: container index %d out of range", pod.Namespace, pod.Name, idx)
+				continue
+			}
+			matchCount++
+			matchedPod = pod
+			matchedContainer = pod.Spec.Containers[idx]
+			matchedDevices = devices
+		}
+	}
+
+	if matchCount == 0 {
+		return nil, v1.Container{}, nil, errors.New("device request not found")
+	}
+	if matchCount > 1 {
+		return nil, v1.Container{}, nil, fmt.Errorf("ambiguous device request matched %d pod containers", matchCount)
+	}
+	return matchedPod, matchedContainer, matchedDevices, nil
+}
+
+func podMatchesNode(pod *v1.Pod, nodeName string) bool {
+	return pod != nil && nodeName != "" && pod.Spec.NodeName == nodeName
+}
+
+func podIdentityAnnotationsMatch(pod *v1.Pod) bool {
+	if pod == nil {
+		return false
+	}
+	// The identity annotations are copied from Volcano's allocation decision.
+	// Require them to match the live Pod object so stale or incorrectly copied
+	// annotations cannot make a different Pod look like the allocation target.
+	return pod.Annotations[AssignedPodNameAnnotations] == pod.Name &&
+		pod.Annotations[AssignedPodNamespaceAnnotations] == pod.Namespace &&
+		pod.Annotations[AssignedPodUIDAnnotations] == string(pod.UID)
+}
+
+func devicesOfType(dtype string, devices ContainerDevices) ContainerDevices {
+	res := ContainerDevices{}
+	for _, dev := range devices {
+		if strings.Compare(dtype, dev.Type) == 0 {
+			res = append(res, dev)
+		}
+	}
+	return res
+}
+
+func deviceIDsMatch(devices ContainerDevices, requestedDeviceIDs []string) bool {
+	if len(devices) != len(requestedDeviceIDs) {
+		return false
+	}
+	expected := map[string]int{}
+	for _, device := range devices {
+		expected[device.UUID]++
+	}
+	for _, requestedDeviceID := range requestedDeviceIDs {
+		if expected[requestedDeviceID] == 0 {
+			return false
+		}
+		expected[requestedDeviceID]--
+	}
+	return true
 }
 
 func EraseNextDeviceTypeFromAnnotation(dtype string, p v1.Pod) error {

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -1,0 +1,155 @@
+package util
+
+import (
+	"strings"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func TestGetPendingPodCanPickWrongOlderPod(t *testing.T) {
+	const nodeName = "gpu-node-1"
+	olderPod := podWithAllocatedDevice("mpi-pod", "default", "older-uid", nodeName, "100", "mpi", "GPU-old")
+	rayPod := podWithAllocatedDevice("ray-pod", "default", "ray-uid", nodeName, "200", "ray-head", "GPU-ray")
+
+	got := getOldestPod([]v1.Pod{*olderPod, *rayPod}, nodeName, 1)
+	if got == nil {
+		t.Fatal("expected getOldestPod to return a pod")
+	}
+	if got.Name != olderPod.Name {
+		t.Fatalf("expected current heuristic to pick older pod %q, got %q", olderPod.Name, got.Name)
+	}
+
+	container, devices, err := GetNextDeviceRequest(NvidiaGPUDevice, *got)
+	if err != nil {
+		t.Fatalf("GetNextDeviceRequest returned error: %v", err)
+	}
+	if container.Name != "mpi" {
+		t.Fatalf("expected wrong older pod container mpi, got %q", container.Name)
+	}
+	if len(devices) != 1 || devices[0].UUID != "GPU-old" {
+		t.Fatalf("expected wrong older pod device GPU-old, got %#v", devices)
+	}
+}
+
+func TestGetMatchingDeviceRequestUsesPodIdentityAndDeviceID(t *testing.T) {
+	const nodeName = "gpu-node-1"
+	olderPod := podWithAllocatedDevice("mpi-pod", "default", "older-uid", nodeName, "100", "mpi", "GPU-old")
+	rayPod := podWithAllocatedDevice("ray-pod", "default", "ray-uid", nodeName, "200", "ray-head", "GPU-ray")
+
+	pod, container, devices, err := GetMatchingDeviceRequest(NvidiaGPUDevice, nodeName, []string{"GPU-ray"}, []v1.Pod{*olderPod, *rayPod})
+	if err != nil {
+		t.Fatalf("GetMatchingDeviceRequest returned error: %v", err)
+	}
+	if pod == nil || pod.Name != rayPod.Name || pod.UID != rayPod.UID {
+		t.Fatalf("expected ray pod %s/%s, got %#v", rayPod.Namespace, rayPod.Name, pod)
+	}
+	if container.Name != "ray-head" {
+		t.Fatalf("expected ray-head container, got %q", container.Name)
+	}
+	if len(devices) != 1 || devices[0].UUID != "GPU-ray" {
+		t.Fatalf("expected GPU-ray device, got %#v", devices)
+	}
+
+	t.Logf("FIXED: kubelet Allocate requested device IDs [GPU-ray] for the Ray container")
+	t.Logf("FIXED: matcher selected pod %s/%s uid=%s", pod.Namespace, pod.Name, pod.UID)
+	t.Logf("FIXED: selected container=%s selected device IDs=[%s]", container.Name, devices[0].UUID)
+	t.Logf("FIXED: HostPath would be /tmp/vgpu/containers/%s_%s", pod.UID, container.Name)
+}
+
+func TestGetMatchingDeviceRequestRejectsAmbiguousDeviceID(t *testing.T) {
+	const nodeName = "gpu-node-1"
+	podA := podWithAllocatedDevice("pod-a", "default", "uid-a", nodeName, "100", "worker", "GPU-shared")
+	podB := podWithAllocatedDevice("pod-b", "default", "uid-b", nodeName, "200", "worker", "GPU-shared")
+
+	_, _, _, err := GetMatchingDeviceRequest(NvidiaGPUDevice, nodeName, []string{"GPU-shared"}, []v1.Pod{*podA, *podB})
+	if err == nil {
+		t.Fatal("expected ambiguous device request error")
+	}
+	if !strings.Contains(err.Error(), "ambiguous") {
+		t.Fatalf("expected ambiguous error, got %v", err)
+	}
+}
+
+func TestGetMatchingDeviceRequestRejectsIdentityMismatch(t *testing.T) {
+	const nodeName = "gpu-node-1"
+	pod := podWithAllocatedDevice("ray-pod", "default", "ray-uid", nodeName, "100", "ray-head", "GPU-ray")
+	pod.Annotations[AssignedPodUIDAnnotations] = "stale-uid"
+
+	_, _, _, err := GetMatchingDeviceRequest(NvidiaGPUDevice, nodeName, []string{"GPU-ray"}, []v1.Pod{*pod})
+	if err == nil {
+		t.Fatal("expected no match when pod identity annotations do not match the pod")
+	}
+	if !strings.Contains(err.Error(), "device request not found") {
+		t.Fatalf("expected not found error, got %v", err)
+	}
+}
+
+func TestGetMatchingDeviceRequestRejectsStaleVNodeAnnotation(t *testing.T) {
+	const nodeName = "gpu-node-1"
+	pod := podWithAllocatedDevice("stale-pod", "default", "stale-uid", "gpu-node-2", "100", "worker", "GPU-ray")
+	pod.Annotations[AssignedNodeAnnotations] = nodeName
+
+	_, _, _, err := GetMatchingDeviceRequest(NvidiaGPUDevice, nodeName, []string{"GPU-ray"}, []v1.Pod{*pod})
+	if err == nil {
+		t.Fatal("expected no match when spec.nodeName and vgpu-node annotation disagree")
+	}
+	if !strings.Contains(err.Error(), "device request not found") {
+		t.Fatalf("expected not found error, got %v", err)
+	}
+}
+
+func TestGetMatchingDeviceRequestSkipsMalformedCandidate(t *testing.T) {
+	const nodeName = "gpu-node-1"
+	malformedPod := podWithAllocatedDevice("bad-pod", "default", "bad-uid", nodeName, "100", "worker", "GPU-ray")
+	malformedPod.Spec.Containers = nil
+	rayPod := podWithAllocatedDevice("ray-pod", "default", "ray-uid", nodeName, "200", "ray-head", "GPU-ray")
+
+	pod, container, devices, err := GetMatchingDeviceRequest(NvidiaGPUDevice, nodeName, []string{"GPU-ray"}, []v1.Pod{*malformedPod, *rayPod})
+	if err != nil {
+		t.Fatalf("GetMatchingDeviceRequest returned error: %v", err)
+	}
+	if pod == nil || pod.Name != rayPod.Name || pod.UID != rayPod.UID {
+		t.Fatalf("expected ray pod %s/%s, got %#v", rayPod.Namespace, rayPod.Name, pod)
+	}
+	if container.Name != "ray-head" {
+		t.Fatalf("expected ray-head container, got %q", container.Name)
+	}
+	if len(devices) != 1 || devices[0].UUID != "GPU-ray" {
+		t.Fatalf("expected GPU-ray device, got %#v", devices)
+	}
+}
+
+func podWithAllocatedDevice(name, namespace, uid, nodeName, vgpuTime, containerName, deviceID string) *v1.Pod {
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			UID:       types.UID(uid),
+			Annotations: map[string]string{
+				AssignedNodeAnnotations:         nodeName,
+				AssignedPodNameAnnotations:      name,
+				AssignedPodNamespaceAnnotations: namespace,
+				AssignedPodUIDAnnotations:       uid,
+				AssignedTimeAnnotations:         vgpuTime,
+				AssignedIDsToAllocateAnnotations: EncodePodDevices(PodDevices{
+					ContainerDevices{{
+						UUID:      deviceID,
+						Type:      NvidiaGPUDevice,
+						Usedmem:   40000,
+						Usedcores: 0,
+					}},
+				}),
+			},
+		},
+		Spec: v1.PodSpec{
+			NodeName: nodeName,
+			Containers: []v1.Container{{
+				Name: containerName,
+			}},
+		},
+	}
+	return pod
+}


### PR DESCRIPTION
## Summary

Use Volcano pod identity annotations plus kubelet-requested device IDs to select the pending vGPU pod/container for non-MIG allocations. This replaces the oldest-pod heuristic in the HAMi vGPU allocation path, preventing the device plugin from building `/tmp/vgpu/containers/<uid>_<container>` from another pending pod when multiple same-node vGPU allocations overlap.

Addresses issue #138.

This PR assumes the pod identity annotations added by volcano-sh/volcano#5570 are present:

- `volcano.sh/vgpu-pod-name`
- `volcano.sh/vgpu-pod-namespace`
- `volcano.sh/vgpu-pod-uid`

That Volcano PR should merge before this one.

## Testing

Master-compatible repro against current heuristic:

```text
=== RUN   TestGetPendingPodCanPickWrongOlderPod
    pending_pod_repro_test.go:36: BUG REPRO: kubelet Allocate requested device IDs [GPU-ray] for the Ray container
    pending_pod_repro_test.go:37: BUG REPRO: getOldestPod selected pod default/mpi-pod uid=older-uid instead of default/ray-pod uid=ray-uid
    pending_pod_repro_test.go:39: BUG REPRO: selected container=mpi selected device IDs=[GPU-old]
    pending_pod_repro_test.go:40: BUG REPRO: HostPath would be /tmp/vgpu/containers/older-uid_mpi instead of /tmp/vgpu/containers/ray-uid_ray-head
--- PASS: TestGetPendingPodCanPickWrongOlderPod (0.00s)
PASS
ok  volcano.sh/k8s-device-plugin/pkg/util  0.571s
```

Branch validation:

```text
=== RUN   TestGetPendingPodCanPickWrongOlderPod
--- PASS: TestGetPendingPodCanPickWrongOlderPod (0.00s)
=== RUN   TestGetMatchingDeviceRequestUsesPodIdentityAndDeviceID
    util_test.go:56: FIXED: kubelet Allocate requested device IDs [GPU-ray] for the Ray container
    util_test.go:57: FIXED: matcher selected pod default/ray-pod uid=ray-uid
    util_test.go:58: FIXED: selected container=ray-head selected device IDs=[GPU-ray]
    util_test.go:59: FIXED: HostPath would be /tmp/vgpu/containers/ray-uid_ray-head
--- PASS: TestGetMatchingDeviceRequestUsesPodIdentityAndDeviceID (0.00s)
=== RUN   TestGetMatchingDeviceRequestRejectsAmbiguousDeviceID
--- PASS: TestGetMatchingDeviceRequestRejectsAmbiguousDeviceID (0.00s)
=== RUN   TestGetMatchingDeviceRequestRejectsIdentityMismatch
--- PASS: TestGetMatchingDeviceRequestRejectsIdentityMismatch (0.00s)
=== RUN   TestGetMatchingDeviceRequestRejectsStaleVNodeAnnotation
--- PASS: TestGetMatchingDeviceRequestRejectsStaleVNodeAnnotation (0.00s)
=== RUN   TestGetMatchingDeviceRequestSkipsMalformedCandidate
W0702 16:13:54.206344   58610 util.go:278] skipping malformed device annotation on pod default/bad-pod: container index 0 out of range
--- PASS: TestGetMatchingDeviceRequestSkipsMalformedCandidate (0.00s)
PASS
ok   volcano.sh/k8s-device-plugin/pkg/util    0.447s
ok   volcano.sh/k8s-device-plugin/pkg/plugin  (cached) [no tests to run]
```
