### PR TITLE
docs: add volcano vGPU contribution templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -15,16 +15,16 @@ labels: bug
 
 **Anything else we need to know?**:
 
-- The output of `nvidia-smi -a` on your host
+- Relevant excerpts from `nvidia-smi -a`; mask GPU UUIDs, serial numbers, and host or node identifiers
 - Relevant Docker or containerd configuration sections. Omit credentials, tokens, passwords, private keys, certificates, and unrelated host data.
-- The volcano-vgpu-device-plugin container logs
-- The volcano-vgpu-monitor container logs, if applicable
-- The volcano-scheduler container logs
-- The kubelet logs on the node (e.g: `sudo journalctl -r -u kubelet`)
+- Relevant, time-bounded excerpts from the volcano-vgpu-device-plugin container logs
+- Relevant, time-bounded excerpts from the volcano-vgpu-monitor container logs, if applicable
+- Relevant, time-bounded excerpts from the volcano-scheduler container logs
+- Relevant, time-bounded excerpts from the kubelet logs on the node (e.g: `sudo journalctl -r -u kubelet`)
 - The relevant Helm values or deployment manifests
-- Any relevant kernel output lines from `dmesg`
+- Relevant, time-bounded kernel output lines from `dmesg`
 
-Before posting, remove or mask credentials, tokens, and other sensitive data from configuration and logs.
+Before posting, remove or mask credentials, tokens, GPU identifiers, node or host identifiers, and other sensitive data from configuration and logs.
 
 **Environment**:
 - volcano-vgpu-device-plugin version:

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,39 @@
+---
+name: Bug Report
+about: Report a problem encountered while using volcano-vgpu-device-plugin
+labels: bug
+---
+
+<!-- Please use this template while reporting a bug and provide as much info as possible. Not doing so may result in your bug not being addressed in a timely manner. Thanks!
+-->
+
+**What happened**:
+
+**What you expected to happen**:
+
+**How to reproduce it (as minimally and precisely as possible)**:
+
+**Anything else we need to know?**:
+
+- The output of `nvidia-smi -a` on your host
+- Relevant Docker or containerd configuration sections. Omit credentials, tokens, passwords, private keys, certificates, and unrelated host data.
+- The volcano-vgpu-device-plugin container logs
+- The volcano-vgpu-monitor container logs, if applicable
+- The volcano-scheduler container logs
+- The kubelet logs on the node (e.g: `sudo journalctl -r -u kubelet`)
+- The relevant Helm values or deployment manifests
+- Any relevant kernel output lines from `dmesg`
+
+Before posting, remove or mask credentials, tokens, and other sensitive data from configuration and logs.
+
+**Environment**:
+- volcano-vgpu-device-plugin version:
+- Volcano version:
+- Kubernetes version:
+- HAMi-core version, if applicable:
+- NVIDIA driver and CUDA version:
+- Docker or containerd version:
+- Installation method, image, and tag used:
+- Sharing mode (`HAMi-core` or `dynamic-mig`):
+- Kernel version from `uname -a`:
+- Others:

--- a/.github/ISSUE_TEMPLATE/enhancement.md
+++ b/.github/ISSUE_TEMPLATE/enhancement.md
@@ -1,0 +1,13 @@
+---
+name: Enhancement Request
+about: Suggest an improvement to volcano-vgpu-device-plugin
+labels: enhancement
+---
+
+<!-- Please use this template for enhancement and feature requests. -->
+
+**What would you like to be added**:
+
+**Why is this needed**:
+
+**Anything else we need to know?**:

--- a/.github/ISSUE_TEMPLATE/good-first.md
+++ b/.github/ISSUE_TEMPLATE/good-first.md
@@ -1,0 +1,23 @@
+---
+name: Good First Issue
+about: Publish a task suitable for a first-time contributor
+labels: "good first issue"
+---
+
+<!-- Please use this template when publishing a good first issue. -->
+
+**Task description**:
+
+**Suggested solution**:
+
+**Who can take this task**:
+
+This issue is intended for a first-time contributor beginning their contribution journey.
+
+**How to take the task**:
+
+Reply to the issue and state that you would like to work on it. A maintainer can assign it to you.
+
+**How to ask for help**:
+
+If you need assistance or have questions, ask in the issue. The issue author or another community member can provide guidance.

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -8,6 +8,8 @@ labels: question
 
 **What have you already tried or investigated?**:
 
+Before posting, include only relevant, time-bounded excerpts and remove or mask credentials, tokens, GPU identifiers, and node or host identifiers.
+
 **Environment**:
 
 - volcano-vgpu-device-plugin version:

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,19 @@
+---
+name: Question
+about: Ask a question about volcano-vgpu-device-plugin
+labels: question
+---
+
+**Please provide a detailed description of your question**:
+
+**What have you already tried or investigated?**:
+
+**Environment**:
+
+- volcano-vgpu-device-plugin version:
+- Volcano and Kubernetes versions:
+- HAMi-core version, if applicable:
+- GPU, NVIDIA driver, and CUDA versions:
+- Docker or containerd version:
+- Installation method and sharing mode:
+- Others:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -21,6 +21,6 @@ Fixes #
 
 **Does this PR introduce a user-facing change?**:
 
-**AI Disclosure**
+**AI Disclosure**:
 
 <!-- Briefly disclose any AI assistance used. Do not add AI co-author or assistance trailers to commits. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+**What type of PR is this?**
+
+<!--
+Add one of the following kinds:
+/kind bug
+/kind cleanup
+/kind deprecation
+/kind design
+/kind documentation
+/kind failing-test
+/kind feature
+/kind flake
+-->
+
+**What this PR does / why we need it**:
+
+**Which issue(s) this PR fixes**:
+Fixes #
+
+**Special notes for your reviewer**:
+
+**Does this PR introduce a user-facing change?**:
+
+**AI Disclosure**
+
+<!-- Briefly disclose any AI assistance used. Do not add AI co-author or assistance trailers to commits. -->


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
-->

/kind documentation

**What this PR does / why we need it**:

Adds concise, repository-specific templates for bug reports, enhancements, good first issues, questions, and pull requests. This helps reports collect consistent Volcano, Kubernetes, GPU, runtime, and reproduction details while keeping the existing project behavior unchanged.

**Which issue(s) this PR fixes**:
Fixes #147

**Special notes for your reviewer**:

This is a documentation-only change. The issue-template front matter was parsed locally, uses existing repository labels, and all five Markdown files were checked for whitespace errors. Runtime configuration prompts request only relevant sections and explicitly exclude credentials and unrelated host data.

**Does this PR introduce a user-facing change?**:

Yes. Contributors will see repository-specific prompts when opening issues and pull requests.

**AI Disclosure**:

AI was used only for formatting purposes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added structured templates for bug reports, enhancement requests, questions, and good-first issues.
  * Added a pull request template covering change details, issue links, reviewer notes, and user-facing impact.
  * Bug reports now prompt for reproduction steps, environment details, logs, and sensitive-data removal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->