### PR TITLE
feat: add nvml-mock support for testing without real GPUs

### DIFF
--- a/cmd/vgpu/main.go
+++ b/cmd/vgpu/main.go
@@ -266,6 +266,13 @@ func loadConfig(c *cli.Context, flags []cli.Flag) (*spec.Config, error) {
 func start(c *cli.Context, o *options) error {
 	klog.InfoS(fmt.Sprintf("Starting %s", c.App.Name), "version", c.App.Version)
 
+	// Resolve the NVML library path from the driver root before the first NVML call.
+	// This ensures the global NVML singleton uses the correct library path when
+	// running with nvml-mock or a custom driver root.
+	driverRoot := root(c.String("driver-root-ctr-path"))
+	libraryPath := driverRoot.tryResolveLibrary("libnvidia-ml.so.1")
+	config.SetNvmlLibraryPath(libraryPath)
+
 	klog.Info("Loading NVML")
 	if nvret := config.Nvml().Init(); nvret != nvml.SUCCESS {
 		klog.Infof("Failed to initialize NVML: %v.", nvret)

--- a/cmd/vgpu/main.go
+++ b/cmd/vgpu/main.go
@@ -266,10 +266,16 @@ func loadConfig(c *cli.Context, flags []cli.Flag) (*spec.Config, error) {
 func start(c *cli.Context, o *options) error {
 	klog.InfoS(fmt.Sprintf("Starting %s", c.App.Name), "version", c.App.Version)
 
-	// Resolve the NVML library path from the driver root before the first NVML call.
-	// This ensures the global NVML singleton uses the correct library path when
-	// running with nvml-mock or a custom driver root.
-	driverRoot := root(c.String("driver-root-ctr-path"))
+	// Load config early to resolve ContainerDriverRoot from config file,
+	// CLI flags, and env vars. This ensures the global NVML singleton uses
+	// the same driver root as the per-plugin NVML instance in startPlugins().
+	cfg, err := loadConfig(c, o.flags)
+	if err != nil {
+		return fmt.Errorf("unable to load config: %v", err)
+	}
+	spec.DisableResourceNamingInConfig(cfg)
+
+	driverRoot := root(*cfg.Flags.Plugin.ContainerDriverRoot)
 	libraryPath := driverRoot.tryResolveLibrary("libnvidia-ml.so.1")
 	config.SetNvmlLibraryPath(libraryPath)
 

--- a/deployments/helm/volcano-vgpu-device-plugin/templates/daemonset.yaml
+++ b/deployments/helm/volcano-vgpu-device-plugin/templates/daemonset.yaml
@@ -56,7 +56,18 @@ spec:
           value: "all"
         - name: NVIDIA_DRIVER_CAPABILITIES
           value: "utility"
-        {{- if .Values.cdi.enabled }}
+        {{- if .Values.nvmlMock.enabled }}
+        - name: NVIDIA_DRIVER_ROOT
+          value: {{ .Values.nvmlMock.driverRoot }}
+        - name: CONTAINER_DRIVER_ROOT
+          value: {{ .Values.nvmlMock.driverRoot }}
+        - name: NVIDIA_DEV_ROOT
+          value: {{ .Values.nvmlMock.driverRoot }}
+        - name: DEVICE_DISCOVERY_STRATEGY
+          value: "nvml"
+        - name: DP_DISABLE_HEALTHCHECKS
+          value: "all"
+        {{- else if .Values.cdi.enabled }}
         - name: DEVICE_LIST_STRATEGY
           value: {{ .Values.cdi.deviceListStrategy }}
         - name: NVIDIA_DRIVER_ROOT
@@ -69,18 +80,6 @@ spec:
           value: "false"
         - name: MOFED_ENABLED
           value: "false"
-        {{- end }}
-        {{- if .Values.nvmlMock.enabled }}
-        - name: NVIDIA_DRIVER_ROOT
-          value: {{ .Values.nvmlMock.driverRoot }}
-        - name: CONTAINER_DRIVER_ROOT
-          value: {{ .Values.nvmlMock.driverRoot }}
-        - name: NVIDIA_DEV_ROOT
-          value: {{ .Values.nvmlMock.driverRoot }}
-        - name: DEVICE_DISCOVERY_STRATEGY
-          value: "nvml"
-        - name: DP_DISABLE_HEALTHCHECKS
-          value: "all"
         {{- end }}
         securityContext:
           allowPrivilegeEscalation: true
@@ -97,7 +96,11 @@ spec:
           mountPath: /usr/local/vgpu
         - name: hosttmp
           mountPath: /tmp
-        {{- if .Values.cdi.enabled }}
+        {{- if .Values.nvmlMock.enabled }}
+        - name: mock-root
+          mountPath: {{ .Values.nvmlMock.driverRoot }}
+          readOnly: true
+        {{- else if .Values.cdi.enabled }}
         - name: cdi-root
           mountPath: /var/run/cdi
         - name: driver-root
@@ -105,11 +108,6 @@ spec:
           readOnly: true
         - name: usrbin
           mountPath: /usrbin
-          readOnly: true
-        {{- end }}
-        {{- if .Values.nvmlMock.enabled }}
-        - name: mock-root
-          mountPath: {{ .Values.nvmlMock.driverRoot }}
           readOnly: true
         {{- end }}
       {{- if and .Values.monitor.enabled (not .Values.nvmlMock.enabled) }}
@@ -189,7 +187,12 @@ spec:
           path: {{ .Values.hostPaths.var }}
           type: Directory
       {{- end }}
-      {{- if .Values.cdi.enabled }}
+      {{- if .Values.nvmlMock.enabled }}
+      - name: mock-root
+        hostPath:
+          path: {{ .Values.nvmlMock.driverRoot }}
+          type: Directory
+      {{- else if .Values.cdi.enabled }}
       - name: driver-root
         hostPath:
           path: /
@@ -201,11 +204,5 @@ spec:
       - name: usrbin
         hostPath:
           path: /usr/bin
-          type: Directory
-      {{- end }}
-      {{- if .Values.nvmlMock.enabled }}
-      - name: mock-root
-        hostPath:
-          path: {{ .Values.nvmlMock.driverRoot }}
           type: Directory
       {{- end }}

--- a/deployments/helm/volcano-vgpu-device-plugin/templates/daemonset.yaml
+++ b/deployments/helm/volcano-vgpu-device-plugin/templates/daemonset.yaml
@@ -70,6 +70,18 @@ spec:
         - name: MOFED_ENABLED
           value: "false"
         {{- end }}
+        {{- if .Values.nvmlMock.enabled }}
+        - name: NVIDIA_DRIVER_ROOT
+          value: {{ .Values.nvmlMock.driverRoot }}
+        - name: CONTAINER_DRIVER_ROOT
+          value: {{ .Values.nvmlMock.driverRoot }}
+        - name: NVIDIA_DEV_ROOT
+          value: {{ .Values.nvmlMock.driverRoot }}
+        - name: DEVICE_DISCOVERY_STRATEGY
+          value: "nvml"
+        - name: DP_DISABLE_HEALTHCHECKS
+          value: "all"
+        {{- end }}
         securityContext:
           allowPrivilegeEscalation: true
           privileged: true
@@ -95,7 +107,12 @@ spec:
           mountPath: /usrbin
           readOnly: true
         {{- end }}
-      {{- if .Values.monitor.enabled }}
+        {{- if .Values.nvmlMock.enabled }}
+        - name: mock-root
+          mountPath: {{ .Values.nvmlMock.driverRoot }}
+          readOnly: true
+        {{- end }}
+      {{- if and .Values.monitor.enabled (not .Values.nvmlMock.enabled) }}
       - name: monitor
         image: "{{ .Values.monitor.image.repository }}:{{ .Values.monitor.image.tag }}"
         command:
@@ -154,7 +171,7 @@ spec:
         hostPath:
           path: {{ .Values.hostPaths.tmp }}
           type: DirectoryOrCreate
-      {{- if .Values.monitor.enabled }}
+      {{- if and .Values.monitor.enabled (not .Values.nvmlMock.enabled) }}
       - name: dockers
         hostPath:
           path: {{ .Values.hostPaths.docker }}
@@ -184,5 +201,11 @@ spec:
       - name: usrbin
         hostPath:
           path: /usr/bin
+          type: Directory
+      {{- end }}
+      {{- if .Values.nvmlMock.enabled }}
+      - name: mock-root
+        hostPath:
+          path: {{ .Values.nvmlMock.driverRoot }}
           type: Directory
       {{- end }}

--- a/deployments/helm/volcano-vgpu-device-plugin/values.yaml
+++ b/deployments/helm/volcano-vgpu-device-plugin/values.yaml
@@ -154,3 +154,14 @@ cdi:
   deviceListStrategy: "cdi-annotations"
   nvidiaHookPath: "/usr/bin/nvidia-ctk"
   nvidiaDriverRoot: "/"
+
+# nvml-mock configuration for testing without real GPUs
+# When enabled, the device-plugin will use the fake NVML library from nvml-mock
+# to simulate GPU devices. The monitor container is automatically disabled.
+# See: https://github.com/nvidia/k8s-test-infra
+nvmlMock:
+  enabled: false
+  # driverRoot is the host-side path where nvml-mock installs the fake driver
+  # (e.g., /var/lib/nvml-mock/driver). This path is mounted into the container
+  # and used as both NVIDIA_DRIVER_ROOT and CONTAINER_DRIVER_ROOT.
+  driverRoot: /var/lib/nvml-mock/driver

--- a/deployments/static/volcano-vgpu-device-plugin-nvml-mock.yml
+++ b/deployments/static/volcano-vgpu-device-plugin-nvml-mock.yml
@@ -179,12 +179,15 @@ spec:
         effect: NoSchedule
       priorityClassName: "system-node-critical"
       serviceAccountName: volcano-device-plugin
+      initContainers:
+      - name: copy-vgpu-lib
+        image: docker.io/projecthami/volcano-vgpu-device-plugin:v1.12.0
+        command: ["/bin/sh", "-c", "cp -f /k8s-vgpu/lib/nvidia/* /usr/local/vgpu/"]
+        volumeMounts:
+        - name: lib
+          mountPath: /usr/local/vgpu
       containers:
       - image: docker.io/projecthami/volcano-vgpu-device-plugin:v1.12.0
-        lifecycle:
-          postStart:
-            exec:
-              command: ["/bin/sh", "-c", "cp -f /k8s-vgpu/lib/nvidia/* /usr/local/vgpu/"]
         name: volcano-device-plugin
         env:
         - name: NODE_NAME

--- a/deployments/static/volcano-vgpu-device-plugin-nvml-mock.yml
+++ b/deployments/static/volcano-vgpu-device-plugin-nvml-mock.yml
@@ -1,0 +1,250 @@
+# Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# This manifest deploys volcano-vgpu-device-plugin configured for use with
+# NVIDIA nvml-mock (https://github.com/nvidia/k8s-test-infra).
+# nvml-mock provides a fake libnvidia-ml.so that simulates GPU devices on
+# nodes without real GPUs, enabling testing of the device-plugin in a
+# kind cluster.
+#
+# Prerequisites:
+#   1. Deploy nvml-mock first: helm install nvml-mock oci://ghcr.io/nvidia/k8s-test-infra/chart/nvml-mock
+#   2. The default driverRoot is /var/lib/nvml-mock/driver — adjust if needed.
+#
+# Note: The monitor container is omitted in this manifest because nvml-mock
+# does not provide real GPU metrics.
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: volcano-vgpu-device-config
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/component: volcano-vgpu-device-plugin
+data:
+  device-config.yaml: |-
+    nvidia:
+      resourceCountName: volcano.sh/vgpu-number
+      resourceMemoryName: volcano.sh/vgpu-memory
+      resourceMemoryPercentageName: volcano.sh/vgpu-memory-percentage
+      resourceCoreName: volcano.sh/vgpu-cores
+      overwriteEnv: false
+      defaultMemory: 0
+      defaultCores: 0
+      defaultGPUNum: 1
+      deviceSplitCount: 10
+      deviceMemoryScaling: 1
+      deviceCoreScaling: 1
+      gpuMemoryFactor: 1
+      knownMigGeometries:
+      - models: [ "A30" ]
+        allowedGeometries:
+          - group: group1
+            geometries:
+            - name: 1g.6gb
+              memory: 6144
+              count: 4
+          - group: group2
+            geometries:
+            - name: 2g.12gb
+              memory: 12288
+              count: 2
+          - group: group3
+            geometries:
+            - name: 4g.24gb
+              memory: 24576
+              count: 1
+      - models: [ "A100-SXM4-40GB", "A100-40GB-PCIe", "A100-PCIE-40GB", "A100-SXM4-40GB" ]
+        allowedGeometries:
+          - group: "group1"
+            geometries:
+            - name: 1g.5gb
+              memory: 5120
+              count: 7
+          - group: "group2"
+            geometries:
+            - name: 2g.10gb
+              memory: 10240
+              count: 3
+            - name: 1g.5gb
+              memory: 5120
+              count: 1
+          - group: "group3"
+            geometries:
+            - name: 3g.20gb
+              memory: 20480
+              count: 2
+          - group: "group4"
+            geometries:
+            - name: 7g.40gb
+              memory: 40960
+              count: 1
+      - models: [ "A100-SXM4-80GB", "A100-80GB-PCIe", "A100-PCIE-80GB"]
+        allowedGeometries:
+          - group: "group1"
+            geometries:
+            - name: 1g.10gb
+              memory: 9728
+              count: 7
+          - group: "group2"
+            geometries:
+            - name: 2g.20gb
+              memory: 19968
+              count: 3
+            - name: 1g.10gb
+              memory: 9728
+              count: 1
+          - group: "group3"
+            geometries:
+            - name: 3g.40gb
+              memory: 40192
+              count: 2
+          - group: "group4"
+            geometries:
+            - name: 7g.80gb
+              memory: 80896
+              count: 1
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: volcano-device-plugin
+  namespace: kube-system
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: volcano-device-plugin
+rules:
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["get", "list", "watch", "update", "patch"]
+- apiGroups: [""]
+  resources: ["nodes/status"]
+  verbs: ["patch"]
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "list", "update", "patch", "watch"]
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["get", "list", "watch", "create", "update"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: volcano-device-plugin
+subjects:
+- kind: ServiceAccount
+  name: volcano-device-plugin
+  namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: volcano-device-plugin
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: volcano-device-plugin
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      name: volcano-device-plugin
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ""
+      labels:
+        name: volcano-device-plugin
+    spec:
+      tolerations:
+      - key: CriticalAddonsOnly
+        operator: Exists
+      - key: volcano.sh/gpu-memory
+        operator: Exists
+        effect: NoSchedule
+      priorityClassName: "system-node-critical"
+      serviceAccountName: volcano-device-plugin
+      containers:
+      - image: docker.io/projecthami/volcano-vgpu-device-plugin:v1.12.0
+        lifecycle:
+          postStart:
+            exec:
+              command: ["/bin/sh", "-c", "cp -f /k8s-vgpu/lib/nvidia/* /usr/local/vgpu/"]
+        name: volcano-device-plugin
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: HOOK_PATH
+          value: "/usr/local/vgpu"
+        - name: NVIDIA_VISIBLE_DEVICES
+          value: "all"
+        - name: NVIDIA_MIG_MONITOR_DEVICES
+          value: "all"
+        - name: NVIDIA_DRIVER_CAPABILITIES
+          value: "utility"
+        # nvml-mock configuration
+        - name: NVIDIA_DRIVER_ROOT
+          value: /var/lib/nvml-mock/driver
+        - name: CONTAINER_DRIVER_ROOT
+          value: /var/lib/nvml-mock/driver
+        - name: NVIDIA_DEV_ROOT
+          value: /var/lib/nvml-mock/driver
+        - name: DEVICE_DISCOVERY_STRATEGY
+          value: "nvml"
+        - name: DP_DISABLE_HEALTHCHECKS
+          value: "all"
+        securityContext:
+          allowPrivilegeEscalation: true
+          privileged: true
+          capabilities:
+            drop: ["ALL"]
+            add: ["SYS_ADMIN"]
+        volumeMounts:
+        - name: deviceconfig
+          mountPath: /config
+        - name: device-plugin
+          mountPath: /var/lib/kubelet/device-plugins
+        - name: lib
+          mountPath: /usr/local/vgpu
+        - name: hosttmp
+          mountPath: /tmp
+        - name: mock-root
+          mountPath: /var/lib/nvml-mock/driver
+          readOnly: true
+      volumes:
+      - name: deviceconfig
+        configMap:
+          name: volcano-vgpu-device-config
+      - hostPath:
+          path: /var/lib/kubelet/device-plugins
+          type: Directory
+        name: device-plugin
+      - hostPath:
+          path: /usr/local/vgpu
+          type: DirectoryOrCreate
+        name: lib
+      - name: hosttmp
+        hostPath:
+          path: /tmp
+          type: DirectoryOrCreate
+      - name: mock-root
+        hostPath:
+          path: /var/lib/nvml-mock/driver
+          type: Directory

--- a/deployments/static/volcano-vgpu-device-plugin-nvml-mock.yml
+++ b/deployments/static/volcano-vgpu-device-plugin-nvml-mock.yml
@@ -138,7 +138,7 @@ rules:
   verbs: ["get", "list", "update", "patch", "watch"]
 - apiGroups: [""]
   resources: ["configmaps"]
-  verbs: ["get", "list", "watch", "create", "update"]
+  verbs: ["get"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -214,11 +214,10 @@ spec:
         - name: DP_DISABLE_HEALTHCHECKS
           value: "all"
         securityContext:
-          allowPrivilegeEscalation: true
-          privileged: true
+          allowPrivilegeEscalation: false
+          privileged: false
           capabilities:
             drop: ["ALL"]
-            add: ["SYS_ADMIN"]
         volumeMounts:
         - name: deviceconfig
           mountPath: /config

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -46,7 +46,9 @@ type NvidiaConfig struct {
 }
 
 var (
-	nvmllib = nvml.New()
+	nvmllib     nvml.Interface
+	nvmlOnce    sync.Once
+	nvmlLibPath string
 
 	lock         sync.Mutex
 	globalDevice device.Interface
@@ -57,7 +59,20 @@ var (
 	DevicePluginFilterDevice *FilterDevice
 )
 
+// SetNvmlLibraryPath configures the library path for the NVML singleton.
+// Must be called before the first call to Nvml().
+func SetNvmlLibraryPath(path string) {
+	nvmlLibPath = path
+}
+
 func Nvml() nvml.Interface {
+	nvmlOnce.Do(func() {
+		if nvmlLibPath != "" {
+			nvmllib = nvml.New(nvml.WithLibraryPath(nvmlLibPath))
+		} else {
+			nvmllib = nvml.New()
+		}
+	})
 	return nvmllib
 }
 
@@ -69,7 +84,11 @@ func Device() device.Interface {
 	lock.Lock()
 	defer lock.Unlock()
 
-	globalDevice = device.New(nvmllib)
+	if globalDevice != nil {
+		return globalDevice
+	}
+
+	globalDevice = device.New(Nvml())
 	return globalDevice
 }
 


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

This PR enables the volcano-vgpu-device-plugin to run on nodes without physical GPUs by integrating NVIDIA's [nvml-mock](https://github.com/nvidia/k8s-test-infra), which provides a fake `libnvidia-ml.so` that simulates GPU devices. This allows developers and users to test the device-plugin's scheduling features in a local kind cluster without access to real GPU hardware — the same approach already used by [HAMi's nvml-mock lab](https://project-hami.io/tutorials/labs/nvml-mock).

**Root blocker fixed**: The global NVML singleton (`config.Nvml()`) was created as `nvml.New()` without `WithLibraryPath()`, causing the plugin to fail or block before ever reaching the code that correctly resolves the library path from `--driver-root-ctr-path`. This PR makes the singleton configurable with a library path.

**Changes**:

1. **`pkg/config/config.go`** — Make the global NVML singleton configurable with a library path via `SetNvmlLibraryPath()`, using `sync.Once` for lazy initialization. When a library path is set, `Nvml()` returns `nvml.New(nvml.WithLibraryPath(path))`; otherwise behavior is unchanged.

2. **`cmd/vgpu/main.go`** — Initialize the global NVML singleton with the driver root library path at startup, before the first `config.Nvml().Init()` call. Uses the same `tryResolveLibrary()` mechanism that `startPlugins()` already uses.

3. **`deployments/helm/volcano-vgpu-device-plugin/values.yaml`** — Add `nvmlMock` configuration section:
   ```yaml
   nvmlMock:
     enabled: false
     driverRoot: /var/lib/nvml-mock/driver
   ```

4. **`deployments/helm/volcano-vgpu-device-plugin/templates/daemonset.yaml`** — When `nvmlMock.enabled=true`, conditionally inject:
   - Environment variables: `NVIDIA_DRIVER_ROOT`, `CONTAINER_DRIVER_ROOT`, `NVIDIA_DEV_ROOT`, `DEVICE_DISCOVERY_STRATEGY=nvml`, `DP_DISABLE_HEALTHCHECKS=all`
   - Volume mount and hostPath volume for the mock driver root
   - Disable the monitor container (fake GPU metrics are not meaningful)

5. **`deployments/static/volcano-vgpu-device-plugin-nvml-mock.yml`** — New static manifest pre-configured for nvml-mock, for users who prefer `kubectl apply` over Helm.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

- No changes to the health check code — the existing `DP_DISABLE_HEALTHCHECKS=all` mechanism is sufficient for disabling health checks in mock environments.
- The `Device()` accessor was updated to use `Nvml()` instead of the raw `nvmllib` variable, and a double-check locking pattern was added for thread safety.
- The monitor container is disabled when nvml-mock is enabled because it relies on the same global NVML singleton and would not provide meaningful metrics for fake GPUs.

**Usage example**:

```bash
# 1. Deploy nvml-mock on a kind cluster
helm install nvml-mock oci://ghcr.io/nvidia/k8s-test-infra/chart/nvml-mock

# 2a. Deploy with Helm
helm install volcano-vgpu-device-plugin deployments/helm/volcano-vgpu-device-plugin \
  --set nvmlMock.enabled=true

# 2b. Or deploy with kubectl
kubectl apply -f deployments/static/volcano-vgpu-device-plugin-nvml-mock.yml
```

**Does this PR introduce a user-facing change?**:

Yes. Users can now run the device-plugin on nodes without real GPUs by enabling the `nvmlMock` Helm value or using the new static manifest. This is a purely additive change — existing deployments are not affected when `nvmlMock.enabled=false` (the default).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added NVML mock mode for operating the vGPU device plugin without physical GPUs.
  - Added Helm settings for mock driver paths, device paths, discovery, and health checks.
  - Added a ready-to-use Kubernetes manifest for NVML mock deployments.
  - Mock mode automatically disables the monitoring sidecar.

- **Improvements**
  - The plugin now locates NVIDIA management libraries under the configured driver root.
  - NVML initialization supports custom library locations for more flexible deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->