### PR TITLE
Sort GPU devices by minor number for stable annotation order

### DIFF
--- a/pkg/plugin/register.go
+++ b/pkg/plugin/register.go
@@ -20,6 +20,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 	"time"
 
@@ -89,6 +90,13 @@ func ConvertDeviceInfo(devs []*pluginapi.Device) *[]*util.DeviceInfo {
 
 		registeredmem := int32(memory.Total/(1024*1024)) / int32(config.GPUMemoryFactor)
 		klog.V(3).Infoln("GPUMemoryFactor=", config.GPUMemoryFactor, "registeredmem=", registeredmem)
+
+		minor, ret := ndev.GetMinorNumber()
+		if ret != nvml.SUCCESS {
+			klog.Warningf("failed to get minor number for device id=%s, setting to -1", dev.ID)
+			minor = -1
+		}
+
 		res = append(res, &util.DeviceInfo{
 			Id:     dev.ID,
 			Count:  int32(config.DeviceSplitCount),
@@ -96,7 +104,13 @@ func ConvertDeviceInfo(devs []*pluginapi.Device) *[]*util.DeviceInfo {
 			Mode:   config.Mode,
 			Type:   fmt.Sprintf("%v-%v", "NVIDIA", model),
 			Health: strings.EqualFold(dev.Health, "healthy"),
+			Minor:  int32(minor),
 		})
 	}
+
+	sort.Slice(res, func(i, j int) bool {
+		return res[i].Minor < res[j].Minor
+	})
+
 	return &res
 }

--- a/pkg/util/types.go
+++ b/pkg/util/types.go
@@ -99,6 +99,7 @@ type DeviceInfo struct {
 	Health               bool              `protobuf:"varint,5,opt,name=health,proto3" json:"health,omitempty"`
 	Mode                 string            `json:"mode,omitempty"`
 	MIGTemplate          []config.Geometry `json:"migtemplate,omitempty"`
+	Minor                int32             `json:"minor,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}          `json:"-"`
 	XXX_unrecognized     []byte            `json:"-"`
 	XXX_sizecache        int32             `json:"-"`


### PR DESCRIPTION
fix issue #150 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Device information now includes each device’s minor number.
  * Devices are returned in minor-number order for consistent presentation.

* **Bug Fixes**
  * Device records remain available when a minor number cannot be retrieved, using a fallback value instead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->